### PR TITLE
Update Udemy course coupon code to JAN-2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/EdenMarco177?style=social)](https://twitter.com/EdenMarco177)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-[![udemy](https://img.shields.io/badge/MCP%20Udemy%20Course%20Coupon%20%2412.99-brightgreen)](https://www.udemy.com/course/model-context-protocol/?couponCode=OCT-2025)
+[![udemy](https://img.shields.io/badge/MCP%20Udemy%20Course%20Coupon%20%2412.99-brightgreen)](https://www.udemy.com/course/model-context-protocol/?couponCode=JAN-2026)
 
 Welcome to the MCP Crash Course! This repository is designed to teach you the fundamentals and advanced concepts of the Model Context Protocol (MCP) in a hands-on way.
 


### PR DESCRIPTION
Change the coupon code from OCT-2025 to JAN-2026 for the new year.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates promotional link in documentation.
> 
> - Changes `README.md` Udemy badge URL to use `couponCode=JAN-2026` (was `OCT-2025`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c11c79596a1aca2a35748033720333098db5caa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->